### PR TITLE
feat: add `shared-script-properties` and script-message to control the osc logo display on idle

### DIFF
--- a/script-opts/SimpleBookmark.conf
+++ b/script-opts/SimpleBookmark.conf
@@ -4,6 +4,9 @@
 #--Auto run the list when opening mpv and there is no video / file loaded. 'none' for disabled. Or choose between: all, keybinds, recents, distinct, protocols, fileonly, titleonly, timeonly, keywords.
 auto_run_list_idle=none
 
+#--hides OSC idle screen message when opening and closing menu (could cause unexpected behavior if multiple scripts are triggering osc-idlescreen off)
+toggle_idlescreen=no
+
 #--change to 0 so item resumes from the exact position, or decrease the value so that it gives you a little preview before loading the resume point
 resume_offset=-0.65
 

--- a/script-opts/SimpleHistory.conf
+++ b/script-opts/SimpleHistory.conf
@@ -4,6 +4,9 @@
 #--Auto run the list when opening mpv and there is no video / file loaded. 'none' for disabled. Or choose between: all, recents, distinct, protocols, fileonly, titleonly, timeonly, keywords.
 auto_run_list_idle=recents
 
+#--hides OSC idle screen message when opening and closing menu (could cause unexpected behavior if multiple scripts are triggering osc-idlescreen off)
+toggle_idlescreen=no
+
 #--change to 0 so item resumes from the exact position, or decrease the value so that it gives you a little preview before loading the resume point
 resume_offset=-0.65
 

--- a/script-opts/SmartCopyPaste_II.conf
+++ b/script-opts/SmartCopyPaste_II.conf
@@ -25,6 +25,9 @@ windows_paste=powershell
 #--Auto run the list when opening mpv and there is no video / file loaded. 'none' for disabled. Or choose between: all, copy, paste, recents, distinct, protocols, fileonly, titleonly, timeonly, keywords.
 auto_run_list_idle=none
 
+#--hides OSC idle screen message when opening and closing menu (could cause unexpected behavior if multiple scripts are triggering osc-idlescreen off)
+toggle_idlescreen=no
+
 #--change to 0 so item resumes from the exact position, or decrease the value so that it gives you a little preview before loading the resume point
 resume_offset=-0.65
 

--- a/scripts/SimpleBookmark.lua
+++ b/scripts/SimpleBookmark.lua
@@ -261,6 +261,8 @@ o.open_list_keybind = utils.parse_json(o.open_list_keybind)
 o.list_filter_jump_keybind = utils.parse_json(o.list_filter_jump_keybind)
 o.list_ignored_keybind = utils.parse_json(o.list_ignored_keybind)
 
+utils.shared_script_property_set("simplebookmark-menu-open", "no")
+
 if string.lower(o.log_path) == '/:dir%mpvconf%' then
 	o.log_path = mp.find_config_file('.')
 elseif string.lower(o.log_path) == '/:dir%script%' then
@@ -1024,6 +1026,7 @@ function display_list(filter, sort, action)
 	
 	if not search_active then get_page_properties(filter) else update_search_results('','') end
 	draw_list()
+	utils.shared_script_property_set("simplebookmark-menu-open", "yes")
 	list_drawn = true
 	if not search_active then get_list_keybinds() end
 end
@@ -1695,6 +1698,7 @@ function unbind_list_keys()
 end
 
 function list_close_and_trash_collection()
+	utils.shared_script_property_set("simplebookmark-menu-open", "no")
 	unbind_list_keys()
 	unbind_search_keys()
 	mp.set_osd_ass(0, 0, "")

--- a/scripts/SimpleBookmark.lua
+++ b/scripts/SimpleBookmark.lua
@@ -11,6 +11,7 @@ local o = {
 
 	-----Script Settings----
 	auto_run_list_idle = 'none',  --Auto run the list when opening mpv and there is no video / file loaded. 'none' for disabled. Or choose between: 'all', 'keybinds', 'recents', 'distinct', 'protocols', 'fileonly', 'titleonly', 'timeonly', 'keywords'.
+	toggle_idlescreen = false, --hides OSC idle screen message when opening and closing menu (could cause unexpected behavior if multiple scripts are triggering osc-idlescreen off)
 	resume_offset = -0.65, --change to 0 so item resumes from the exact position, or decrease the value so that it gives you a little preview before loading the resume point
 	osd_messages = true, --true is for displaying osd messages when actions occur. Change to false will disable all osd messages generated from this script
 	bookmark_loads_last_idle = true, --When attempting to bookmark, if there is no video / file loaded, it will instead jump to your last bookmarked item and resume it.
@@ -1027,6 +1028,7 @@ function display_list(filter, sort, action)
 	if not search_active then get_page_properties(filter) else update_search_results('','') end
 	draw_list()
 	utils.shared_script_property_set("simplebookmark-menu-open", "yes")
+	if o.toggle_idlescreen then mp.commandv('script-message', 'osc-idlescreen', 'no', 'no_osd') end
 	list_drawn = true
 	if not search_active then get_list_keybinds() end
 end
@@ -1699,6 +1701,7 @@ end
 
 function list_close_and_trash_collection()
 	utils.shared_script_property_set("simplebookmark-menu-open", "no")
+	if o.toggle_idlescreen then mp.commandv('script-message', 'osc-idlescreen', 'yes', 'no_osd') end
 	unbind_list_keys()
 	unbind_search_keys()
 	mp.set_osd_ass(0, 0, "")

--- a/scripts/SimpleHistory.lua
+++ b/scripts/SimpleHistory.lua
@@ -11,6 +11,7 @@ local o = {
 
 	-----Script Settings----
 	auto_run_list_idle = 'recents', --Auto run the list when opening mpv and there is no video / file loaded. 'none' for disabled. Or choose between: 'all', 'recents', 'distinct', 'protocols', 'fileonly', 'titleonly', 'timeonly', 'keywords'.
+	toggle_idlescreen = false, --hides OSC idle screen message when opening and closing menu (could cause unexpected behavior if multiple scripts are triggering osc-idlescreen off)
 	resume_offset = -0.65, --change to 0 so item resumes from the exact position, or decrease the value so that it gives you a little preview before loading the resume point
 	osd_messages = true, --true is for displaying osd messages when actions occur. Change to false will disable all osd messages generated from this script
 	resume_notification = true, --true so that when a file that is played previously, a notification to resume to the previous reached time will be triggered
@@ -252,7 +253,7 @@ o.open_list_keybind = utils.parse_json(o.open_list_keybind)
 o.list_filter_jump_keybind = utils.parse_json(o.list_filter_jump_keybind)
 o.list_ignored_keybind = utils.parse_json(o.list_ignored_keybind)
 
-utils.shared_script_property_set("simplehistory-menu-open", "no")
+utils.shared_script_property_set("menu-open", "no")
 
 if string.lower(o.log_path) == '/:dir%mpvconf%' then
 	o.log_path = mp.find_config_file('.')
@@ -974,6 +975,7 @@ function display_list(filter, sort, action)
 	if not search_active then get_page_properties(filter) else update_search_results('','') end
 	draw_list()
 	utils.shared_script_property_set("simplehistory-menu-open", "yes")
+	if o.toggle_idlescreen then mp.commandv('script-message', 'osc-idlescreen', 'yes', 'no_osd') end
 	list_drawn = true
 	if not search_active then get_list_keybinds() end
 end
@@ -1636,6 +1638,7 @@ end
 
 function list_close_and_trash_collection()
 	utils.shared_script_property_set("simplehistory-menu-open", "no")
+	if o.toggle_idlescreen then mp.commandv('script-message', 'osc-idlescreen', 'yes', 'no_osd') end
 	unbind_list_keys()
 	unbind_search_keys()
 	mp.set_osd_ass(0, 0, "")

--- a/scripts/SimpleHistory.lua
+++ b/scripts/SimpleHistory.lua
@@ -252,6 +252,8 @@ o.open_list_keybind = utils.parse_json(o.open_list_keybind)
 o.list_filter_jump_keybind = utils.parse_json(o.list_filter_jump_keybind)
 o.list_ignored_keybind = utils.parse_json(o.list_ignored_keybind)
 
+utils.shared_script_property_set("simplehistory-menu-open", "no")
+
 if string.lower(o.log_path) == '/:dir%mpvconf%' then
 	o.log_path = mp.find_config_file('.')
 elseif string.lower(o.log_path) == '/:dir%script%' then
@@ -971,6 +973,7 @@ function display_list(filter, sort, action)
 	
 	if not search_active then get_page_properties(filter) else update_search_results('','') end
 	draw_list()
+	utils.shared_script_property_set("simplehistory-menu-open", "yes")
 	list_drawn = true
 	if not search_active then get_list_keybinds() end
 end
@@ -1632,6 +1635,7 @@ function unbind_list_keys()
 end
 
 function list_close_and_trash_collection()
+	utils.shared_script_property_set("simplehistory-menu-open", "no")
 	unbind_list_keys()
 	unbind_search_keys()
 	mp.set_osd_ass(0, 0, "")

--- a/scripts/SmartCopyPaste_II.lua
+++ b/scripts/SmartCopyPaste_II.lua
@@ -287,6 +287,8 @@ o.open_list_keybind = utils.parse_json(o.open_list_keybind)
 o.list_filter_jump_keybind = utils.parse_json(o.list_filter_jump_keybind)
 o.list_ignored_keybind = utils.parse_json(o.list_ignored_keybind)
 
+utils.shared_script_property_set("smartcopypaste-menu-open", "no")
+
 if string.lower(o.log_path) == '/:dir%mpvconf%' then
 	o.log_path = mp.find_config_file('.')
 elseif string.lower(o.log_path) == '/:dir%script%' then
@@ -1044,6 +1046,7 @@ function display_list(filter, sort, action)
 	
 	if not search_active then get_page_properties(filter) else update_search_results('','') end
 	draw_list()
+	utils.shared_script_property_set("smartcopypaste-menu-open", "yes")
 	list_drawn = true
 	if not search_active then get_list_keybinds() end
 end
@@ -1705,6 +1708,7 @@ function unbind_list_keys()
 end
 
 function list_close_and_trash_collection()
+	utils.shared_script_property_set("smartcopypaste-menu-open", "no")
 	unbind_list_keys()
 	unbind_search_keys()
 	mp.set_osd_ass(0, 0, "")

--- a/scripts/SmartCopyPaste_II.lua
+++ b/scripts/SmartCopyPaste_II.lua
@@ -18,6 +18,7 @@ local o = {
 	windows_copy = 'powershell', --'powershell' is for using windows powershell to copy. OR write the copy command, e.g: ' clip'
 	windows_paste = 'powershell', --'powershell' is for using windows powershell to paste. OR write the paste command
 	auto_run_list_idle = 'none', --Auto run the list when opening mpv and there is no video / file loaded. 'none' for disabled. Or choose between: 'all', 'copy', 'paste', 'recents', 'distinct', 'protocols', 'fileonly', 'titleonly', 'timeonly', 'keywords'.	
+	toggle_idlescreen = false, --hides OSC idle screen message when opening and closing menu (could cause unexpected behavior if multiple scripts are triggering osc-idlescreen off)
 	resume_offset = -0.65, --change to 0 so item resumes from the exact position, or decrease the value so that it gives you a little preview before loading the resume point
 	osd_messages = true, --true is for displaying osd messages when actions occur. Change to false will disable all osd messages generated from this script
 	mark_clipboard_as_chapter = false, --true is for marking the time as a chapter. false disables mark as chapter behavior.
@@ -287,7 +288,7 @@ o.open_list_keybind = utils.parse_json(o.open_list_keybind)
 o.list_filter_jump_keybind = utils.parse_json(o.list_filter_jump_keybind)
 o.list_ignored_keybind = utils.parse_json(o.list_ignored_keybind)
 
-utils.shared_script_property_set("smartcopypaste-menu-open", "no")
+utils.shared_script_property_set("menu-open", "no")
 
 if string.lower(o.log_path) == '/:dir%mpvconf%' then
 	o.log_path = mp.find_config_file('.')
@@ -1047,6 +1048,7 @@ function display_list(filter, sort, action)
 	if not search_active then get_page_properties(filter) else update_search_results('','') end
 	draw_list()
 	utils.shared_script_property_set("smartcopypaste-menu-open", "yes")
+	if o.toggle_idlescreen then mp.commandv('script-message', 'osc-idlescreen', 'no', 'no_osd') end
 	list_drawn = true
 	if not search_active then get_list_keybinds() end
 end
@@ -1709,6 +1711,7 @@ end
 
 function list_close_and_trash_collection()
 	utils.shared_script_property_set("smartcopypaste-menu-open", "no")
+	if o.toggle_idlescreen then mp.commandv('script-message', 'osc-idlescreen', 'yes', 'no_osd') end
 	unbind_list_keys()
 	unbind_search_keys()
 	mp.set_osd_ass(0, 0, "")


### PR DESCRIPTION
Code refer to https://github.com/CogentRedTester/mpv-file-browser/commit/b90c5a94edf3dd5497cab64e6178b0502e0cfb38
This allows users to set conditional auto-profiles depending on the open state of menu.
Here is an example of an auto-profile that hides the OSC logo when menu is open in an idle window:

```properties
[hide-logo]
profile-cond=idle_active and shared_script_properties["menu-open"] == "yes"
profile-restore=copy
script-opts-append=osc-visibility=never

```
Close https://github.com/Eisa01/mpv-scripts/issues/47