### PR TITLE
fix `shared-script-properties` property

### DIFF
--- a/scripts/SimpleHistory.lua
+++ b/scripts/SimpleHistory.lua
@@ -253,7 +253,7 @@ o.open_list_keybind = utils.parse_json(o.open_list_keybind)
 o.list_filter_jump_keybind = utils.parse_json(o.list_filter_jump_keybind)
 o.list_ignored_keybind = utils.parse_json(o.list_ignored_keybind)
 
-utils.shared_script_property_set("menu-open", "no")
+utils.shared_script_property_set("simplehistory-menu-open", "no")
 
 if string.lower(o.log_path) == '/:dir%mpvconf%' then
 	o.log_path = mp.find_config_file('.')

--- a/scripts/SmartCopyPaste_II.lua
+++ b/scripts/SmartCopyPaste_II.lua
@@ -288,7 +288,7 @@ o.open_list_keybind = utils.parse_json(o.open_list_keybind)
 o.list_filter_jump_keybind = utils.parse_json(o.list_filter_jump_keybind)
 o.list_ignored_keybind = utils.parse_json(o.list_ignored_keybind)
 
-utils.shared_script_property_set("menu-open", "no")
+utils.shared_script_property_set("smartcopypaste-menu-open", "no")
 
 if string.lower(o.log_path) == '/:dir%mpvconf%' then
 	o.log_path = mp.find_config_file('.')


### PR DESCRIPTION
This commit https://github.com/Eisa01/mpv-scripts/commit/830ffbec0564edc2b5931a04bbab1222da871e2b introduces a error regression, It's my mistake.
Fix it.