### PR TITLE
Prepare for shared-script-properties removal

### DIFF
--- a/scripts/SimpleBookmark.lua
+++ b/scripts/SimpleBookmark.lua
@@ -290,7 +290,10 @@ o.open_list_keybind = utils.parse_json(o.open_list_keybind)
 o.list_filter_jump_keybind = utils.parse_json(o.list_filter_jump_keybind)
 o.list_ignored_keybind = utils.parse_json(o.list_ignored_keybind)
 
-utils.shared_script_property_set("simplebookmark-menu-open", "no")
+if utils.shared_script_property_set then
+	utils.shared_script_property_set('simplebookmark-menu-open', 'no')
+end
+mp.set_property('user-data/simplebookmark/menu-open', 'no')
 
 if string.lower(o.log_path) == '/:dir%mpvconf%' then
 	o.log_path = mp.find_config_file('.')
@@ -1277,7 +1280,10 @@ function display_list(filter, sort, action)
 	
 	if not search_active then get_page_properties(filter) else update_search_results('','') end
 	draw_list(osd_log_contents)
-	utils.shared_script_property_set("simplebookmark-menu-open", "yes")
+	if utils.shared_script_property_set then
+		utils.shared_script_property_set('simplebookmark-menu-open', 'yes')
+	end
+	mp.set_property('user-data/simplebookmark/menu-open', 'yes')
 	if o.toggle_idlescreen then mp.commandv('script-message', 'osc-idlescreen', 'no', 'no_osd') end
 	list_drawn = true
 	if not search_active then get_list_keybinds() end
@@ -1958,7 +1964,10 @@ function unbind_list_keys()
 end
 
 function list_close_and_trash_collection()
-	utils.shared_script_property_set("simplebookmark-menu-open", "no")
+	if utils.shared_script_property_set then
+		utils.shared_script_property_set('simplebookmark-menu-open', 'no')
+	end
+	mp.set_property('user-data/simplebookmark/menu-open', 'no')
 	if o.toggle_idlescreen then mp.commandv('script-message', 'osc-idlescreen', 'yes', 'no_osd') end
 	unbind_list_keys()
 	unbind_search_keys()

--- a/scripts/SimpleHistory.lua
+++ b/scripts/SimpleHistory.lua
@@ -254,7 +254,10 @@ o.open_list_keybind = utils.parse_json(o.open_list_keybind)
 o.list_filter_jump_keybind = utils.parse_json(o.list_filter_jump_keybind)
 o.list_ignored_keybind = utils.parse_json(o.list_ignored_keybind)
 
-utils.shared_script_property_set("simplehistory-menu-open", "no")
+if utils.shared_script_property_set then
+    utils.shared_script_property_set('simplehistory-menu-open', 'no')
+end
+mp.set_property('user-data/simplehistory/menu-open', 'no')
 
 if string.lower(o.log_path) == '/:dir%mpvconf%' then
 	o.log_path = mp.find_config_file('.')
@@ -977,7 +980,10 @@ function display_list(filter, sort, action)
 	
 	if not search_active then get_page_properties(filter) else update_search_results('','') end
 	draw_list()
-	utils.shared_script_property_set("simplehistory-menu-open", "yes")
+	if utils.shared_script_property_set then
+		utils.shared_script_property_set('simplehistory-menu-open', 'yes')
+	end
+	mp.set_property('user-data/simplehistory/menu-open', 'yes')
 	if o.toggle_idlescreen then mp.commandv('script-message', 'osc-idlescreen', 'no', 'no_osd') end --1.1.6# fix osc-idlescreen (value was yes for some reason)
 	list_drawn = true
 	if not search_active then get_list_keybinds() end
@@ -1640,7 +1646,10 @@ function unbind_list_keys()
 end
 
 function list_close_and_trash_collection()
-	utils.shared_script_property_set("simplehistory-menu-open", "no")
+	if utils.shared_script_property_set then
+		utils.shared_script_property_set('simplehistory-menu-open', 'no')
+	end
+	mp.set_property('user-data/simplehistory/menu-open', 'no')
 	if o.toggle_idlescreen then mp.commandv('script-message', 'osc-idlescreen', 'yes', 'no_osd') end
 	unbind_list_keys()
 	unbind_search_keys()

--- a/scripts/SmartCopyPaste_II.lua
+++ b/scripts/SmartCopyPaste_II.lua
@@ -288,7 +288,10 @@ o.open_list_keybind = utils.parse_json(o.open_list_keybind)
 o.list_filter_jump_keybind = utils.parse_json(o.list_filter_jump_keybind)
 o.list_ignored_keybind = utils.parse_json(o.list_ignored_keybind)
 
-utils.shared_script_property_set("smartcopypaste-menu-open", "no")
+if utils.shared_script_property_set then
+    utils.shared_script_property_set('smartcopypaste-menu-open', 'no')
+end
+mp.set_property('user-data/smartcopypaste/menu-open', 'no')
 
 if string.lower(o.log_path) == '/:dir%mpvconf%' then
 	o.log_path = mp.find_config_file('.')
@@ -1047,7 +1050,10 @@ function display_list(filter, sort, action)
 	
 	if not search_active then get_page_properties(filter) else update_search_results('','') end
 	draw_list()
-	utils.shared_script_property_set("smartcopypaste-menu-open", "yes")
+	if utils.shared_script_property_set then
+		utils.shared_script_property_set('smartcopypaste-menu-open', 'yes')
+	end
+	mp.set_property('user-data/smartcopypaste/menu-open', 'yes')
 	if o.toggle_idlescreen then mp.commandv('script-message', 'osc-idlescreen', 'no', 'no_osd') end
 	list_drawn = true
 	if not search_active then get_list_keybinds() end
@@ -1710,7 +1716,10 @@ function unbind_list_keys()
 end
 
 function list_close_and_trash_collection()
-	utils.shared_script_property_set("smartcopypaste-menu-open", "no")
+	if utils.shared_script_property_set then
+		utils.shared_script_property_set('smartcopypaste-menu-open', 'no')
+	end
+	mp.set_property('user-data/smartcopypaste/menu-open', 'no')
 	if o.toggle_idlescreen then mp.commandv('script-message', 'osc-idlescreen', 'yes', 'no_osd') end
 	unbind_list_keys()
 	unbind_search_keys()


### PR DESCRIPTION
mpv is about to remove `shared-script-properties`, which will cause `utils.shared_script_property_set` to be nil.
Check for it's existence before calling it.
Also fall back to user-data in case they aren't available anymore.
Ref https://github.com/mpv-player/mpv/pull/12456