### PR TITLE
Check and fix if `video_duration` is `nil`

### DIFF
--- a/scripts/SimpleHistory.lua
+++ b/scripts/SimpleHistory.lua
@@ -2116,6 +2116,11 @@ function history_resume_option()
 		local logged_time = 0
 		local percentage = 0
 		local video_duration = mp.get_property_number('duration')
+		if video_duration and video_duration ~= nil then
+			video_duration = tonumber(video_duration)
+		else
+			video_duration = 0
+		end	
 		list_contents = read_log_table()
 		if not list_contents or not list_contents[1] then return end
 		for i = #list_contents, 1, -1 do

--- a/scripts/SimpleHistory.lua
+++ b/scripts/SimpleHistory.lua
@@ -2115,12 +2115,8 @@ function history_resume_option()
 		if video_time > 0 then return end
 		local logged_time = 0
 		local percentage = 0
-		local video_duration = mp.get_property_number('duration')
-		if video_duration and video_duration ~= nil then
-			video_duration = tonumber(video_duration)
-		else
-			video_duration = 0
-		end	
+		local video_duration = mp.get_property_number('duration') or 0
+
 		list_contents = read_log_table()
 		if not list_contents or not list_contents[1] then return end
 		for i = #list_contents, 1, -1 do

--- a/scripts/SimpleHistory.lua
+++ b/scripts/SimpleHistory.lua
@@ -2115,8 +2115,7 @@ function history_resume_option()
 		if video_time > 0 then return end
 		local logged_time = 0
 		local percentage = 0
-		local video_duration = mp.get_property_number('duration') or 0
-
+		local video_duration = (mp.get_property_number('duration') or 0)
 		list_contents = read_log_table()
 		if not list_contents or not list_contents[1] then return end
 		for i = #list_contents, 1, -1 do


### PR DESCRIPTION
`video_duration` could be `nil` in certain streaming scenarios where the duration is unknown ahead of time, e.g., real-time streaming with RTSP streams. If unchecked for a nil value, `video_duration` will lead to the following error otherwise:

```
[SimpleHistory]         [C]: ?
[SimpleHistory]         [C]: ?
[SimpleHistory] Lua error: /Users/name/.config/mpv/scripts/SimpleHistory.lua:2131: attempt to perform arithmetic on local 'video_duration' (a nil value)
```