### PR TITLE
Add support for pasting from primary clipboard buffer on linux

### DIFF
--- a/script-opts/SmartCopyPaste.conf
+++ b/script-opts/SmartCopyPaste.conf
@@ -5,10 +5,13 @@
 device=auto
 
 #--copy command that will be used in Linux. OR write a different command
-linux_copy=xclip -silent -selection clipboard -in
+linux_copy=xclip -silent -selection clipboard -i
 
 #--paste command that will be used in Linux. OR write a different command
 linux_paste=xclip -selection clipboard -o
+
+#--paste command that will be used in Linux on middle click
+linux_paste_primary=xclip -selection primary -o
 
 #--copy command that will be used in MAC. OR write a different command
 mac_copy=pbcopy
@@ -69,6 +72,9 @@ paste_specific_behavior=playlist
 
 #--Keybind that will be used to paste based on the paste behavior specified
 paste_specific_keybind=["ctrl+alt+v", "ctrl+alt+V", "meta+alt+v", "meta+alt+V"]
+
+#--Keybind that will be used to paste from primary buffer on Linux
+paste_primary_keybind=["MBTN_MID"]
 
 #--add below (after a comma) any protocol you want paste to work with; e.g: ,'ftp://'. Or set it as "" by deleting all defined protocols to make paste works with any protocol.
 paste_protocols=["https?://", "magnet:", "rtmp:", "file:"]


### PR DESCRIPTION
On Linux, there exists another clipboard buffer (called _primary_). This buffer simply contains the text that was selected last. Usually the text from this buffer can be pasted by pressing the middle button on the mouse. I often use this feature, as it’s a bit faster than using Ctrl+C and Ctrl+V and it can be utilized completely without using the keyboard.

This pull requests adds support for pasting from this buffer to SmartCopyPaste.